### PR TITLE
prometheus-bitcoind.py: Add log output when server starts

### DIFF
--- a/scripts/prometheus-bitcoind.py
+++ b/scripts/prometheus-bitcoind.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import json
 import time
 import subprocess
@@ -98,7 +99,7 @@ def get_raw_tx(txid):
 
 
 def main():
-    # Start up the server to expose the metrics.
+    print('Starting HTTP server exposing Prometheus metrics on :8334..')
     start_http_server(8334)
     while True:
         blockchaininfo = bitcoin('getblockchaininfo')


### PR DESCRIPTION
Otherwise, the naive user (like me) could be confused when nothing seems to happen, where in actuality the script is running the HTTP server exposing Prometheus metrics fine.